### PR TITLE
Add VTT as a supported format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,10 @@ serde = { version = "1.0.209", features = ["derive"] }
 serde_json = "1.0.127"
 serde_yml = "0.0.12"
 srv3-ttml = { path = "crates/srv3-ttml", version = "0.1.0"}
+srv3tovtt-crate = { path = "crates/srv3tovtt-crate" }
 
 [workspace]
 members = [
-   "crates/srv3-ttml"
+   "crates/srv3-ttml",
+   "crates/srv3tovtt-crate"
 ]

--- a/crates/srv3tovtt-crate/Cargo.toml
+++ b/crates/srv3tovtt-crate/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "srv3tovtt-crate"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+aspasia = "0.2.1"
+serde = "1.0.210"
+srv3-ttml = { path = "../srv3-ttml" }

--- a/crates/srv3tovtt-crate/src/lib.rs
+++ b/crates/srv3tovtt-crate/src/lib.rs
@@ -1,0 +1,71 @@
+use std::fmt::Write;
+
+pub use aspasia::timing::Moment;
+use serde::{Deserialize, Serialize};
+use srv3_ttml::BodyElement;
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Paragraph {
+    inner: Vec<BodyElement>,
+    timestamp: u32,
+    duration: u32,
+    window_position: Option<u32>,
+    window_style: Option<u32>,
+}
+
+trait ElementExt {
+    fn text(&self) -> String;
+}
+
+impl ElementExt for String {
+    fn text(&self) -> String {
+        self.clone()
+    }
+}
+impl ElementExt for BodyElement {
+    fn text(&self) -> String {
+        match self {
+            Self::Text(t) => t.text(),
+            _ => String::new(),
+        }
+    }
+}
+impl ElementExt for Vec<BodyElement> {
+    fn text(&self) -> String {
+        self.iter()
+            .fold(String::new(), |acc, elem| acc + &elem.text() + "\n")
+            .trim()
+            .to_string()
+    }
+}
+
+pub fn to_vtt(captions: &srv3_ttml::TimedText) -> std::io::Result<String> {
+    let paragraph = &captions.body.elements;
+    let mut w = String::new();
+    writeln!(&mut w, "WEBVTT").unwrap();
+    writeln!(&mut w, "Kind: captions").unwrap();
+    writeln!(&mut w, "Language: en").unwrap();
+    for element in paragraph {
+        writeln!(&mut w, "").unwrap();
+        match element {
+            BodyElement::Text(_text) => {}
+            BodyElement::Paragraph(paragraph) => writeln!(
+                &mut w,
+                "{} --> {}\n{}",
+                aspasia::timing::Moment::as_vtt_timestamp(&aspasia::timing::Moment::from(
+                    paragraph.timestamp as i64
+                )),
+                aspasia::timing::Moment::as_vtt_timestamp(&aspasia::timing::Moment::from(
+                    paragraph.timestamp as i64 + paragraph.duration as i64
+                )),
+                paragraph.inner.text()
+            )
+            .unwrap(),
+            BodyElement::Span(_span) => {}
+            BodyElement::Br(_br) => {}
+            BodyElement::Div(_div) => {}
+            BodyElement::Window(_window) => {}
+        }
+    }
+    Ok(w)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,11 @@ use std::str::FromStr;
 use clap::Parser;
 
 #[derive(Parser)]
-#[clap(version, about, long_about = "A tool to parse and process YouTube SRV3 captions")]
+#[clap(
+    version,
+    about,
+    long_about = "A tool to parse and process YouTube SRV3 captions"
+)]
 struct Args {
     #[clap(subcommand)]
     subcmd: SubCommand,
@@ -16,6 +20,8 @@ enum OutputFormat {
     Json,
     /// YAML format
     Yaml,
+    /// VTT format
+    Vtt,
 }
 
 // subcommands
@@ -27,7 +33,7 @@ enum SubCommand {
         // positional
         /// Path to the input file
         input: String,
-        
+
         /// Output format
         #[clap(short, long, default_value = "json")]
         format: OutputFormat,
@@ -39,14 +45,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     match args.subcmd {
         SubCommand::Parse { input, format } => {
             println!("Parsing file: {}", input);
-            
+
             let file = std::fs::read_to_string(input)?;
-     
-            
+
             let captions = srv3_ttml::TimedText::from_str(&file)?;
-            
+
             // println!("Parsed captions: {:?}", captions);
-            
+
             match format {
                 OutputFormat::Json => {
                     println!("{}", serde_json::to_string_pretty(&captions)?);
@@ -54,10 +59,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 OutputFormat::Yaml => {
                     println!("{}", serde_yml::to_string(&captions)?);
                 }
+                OutputFormat::Vtt => {
+                    println!("{}", srv3tovtt_crate::to_vtt(&captions)?);
+                }
             }
-            
         }
     }
     Ok(())
 }
-


### PR DESCRIPTION
This commit adds the VTT subtitle format as a parse option.
How to use: simply add `--format vtt` as with JSON or Yaml to the command line.
![image](https://github.com/user-attachments/assets/baf11147-6690-462b-bb75-4a99c476c558)
