### PR TITLE
add SRT conversion support + saving to file

### DIFF
--- a/crates/srv3tovtt-crate/src/lib.rs
+++ b/crates/srv3tovtt-crate/src/lib.rs
@@ -1,8 +1,8 @@
-use std::fmt::Write;
-
 pub use aspasia::timing::Moment;
 use serde::{Deserialize, Serialize};
 use srv3_ttml::BodyElement;
+use std::fmt::Write;
+use std::str::FromStr;
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Paragraph {
@@ -69,3 +69,10 @@ pub fn to_vtt(captions: &srv3_ttml::TimedText) -> std::io::Result<String> {
     }
     Ok(w)
 }
+
+pub fn to_srt(captions: &srv3_ttml::TimedText) -> Result<String, Box<dyn std::error::Error>> {
+    let vtt = to_vtt(captions)?;
+    let vtt_subtitle = aspasia::WebVttSubtitle::from_str(&vtt)?;
+    let srt_subtitle = aspasia::SubRipSubtitle::from(&vtt_subtitle);
+    Ok(srt_subtitle.to_string())
+} // Kind of a hacky solution, but because SubRip doesn't offer anything extra over WebVTT, it is plausible

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,6 @@
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
 use std::str::FromStr;
 
 use clap::Parser;
@@ -22,6 +25,16 @@ enum OutputFormat {
     Yaml,
     /// VTT format
     Vtt,
+    /// SRT format
+    Srt,
+}
+
+#[derive(clap::ValueEnum, Debug, Clone, Copy)]
+enum SaveLocation {
+    /// Print the converted subtitles to stdout
+    Stdout,
+    /// Save the converted subtitles to a file
+    File,
 }
 
 // subcommands
@@ -37,30 +50,61 @@ enum SubCommand {
         /// Output format
         #[clap(short, long, default_value = "json")]
         format: OutputFormat,
+
+        /// Save to file or print to stdout
+        #[clap(short, long, default_value = "stdout")]
+        save: SaveLocation,
+
+        /// File path to save the output file to
+        #[clap(short, long, default_value = "")]
+        output: String,
     },
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
     match args.subcmd {
-        SubCommand::Parse { input, format } => {
+        SubCommand::Parse {
+            input,
+            format,
+            save,
+            output,
+        } => {
             println!("Parsing file: {}", input);
 
-            let file = std::fs::read_to_string(input)?;
+            let file = std::fs::read_to_string(&input)?;
 
             let captions = srv3_ttml::TimedText::from_str(&file)?;
 
             // println!("Parsed captions: {:?}", captions);
 
-            match format {
-                OutputFormat::Json => {
-                    println!("{}", serde_json::to_string_pretty(&captions)?);
-                }
-                OutputFormat::Yaml => {
-                    println!("{}", serde_yml::to_string(&captions)?);
-                }
-                OutputFormat::Vtt => {
-                    println!("{}", srv3tovtt_crate::to_vtt(&captions)?);
+            let w = match format {
+                OutputFormat::Json => serde_json::to_string_pretty(&captions)?,
+                OutputFormat::Yaml => serde_yml::to_string(&captions)?,
+                OutputFormat::Vtt => srv3tovtt_crate::to_vtt(&captions)?,
+                OutputFormat::Srt => srv3tovtt_crate::to_srt(&captions)?,
+            };
+            match save {
+                SaveLocation::Stdout => println!("{}", w),
+                SaveLocation::File => {
+                    if output.is_empty() {
+                        let file_stem = Path::new(&input)
+                            .file_stem()
+                            .and_then(|s| s.to_str())
+                            .unwrap_or_default();
+                        let extension = format!("{:?}", format).to_lowercase();
+                        let mut outputfile =
+                            File::create(format!("./{}.{}", file_stem, extension))?; //if the user doesnt specify the output directory, but wants to save to file, output it with the same name and correct extension to working directory.
+                        writeln!(&mut outputfile, "{}", w)?;
+                        println!(
+                            "Successfully wrote subtitles to ./{}.{}",
+                            file_stem, extension
+                        );
+                    } else {
+                        let mut outputfile = File::create(&output)?;
+                        writeln!(&mut outputfile, "{}", w)?;
+                        println!("Successfully wrote subtitles to {}", output);
+                    }
                 }
             }
         }


### PR DESCRIPTION
This commit adds support for converting to the SubRip subtitle format, closing #4 
This commit also adds support for saving the converted result to a file directly, instead of printing to stdout with `--save file` and `--output /path/to/export.format`
if `--output` is empty, it saves to the current working directory, automatically getting the extension of the requested format

printing to stdout is still supported with `--save stdout`, which is default behavior
![image](https://github.com/user-attachments/assets/728f7d39-9912-4f6d-936c-f35ad31036de)

![image](https://github.com/user-attachments/assets/35783bc4-a09c-4405-a563-4169a2d50092)
